### PR TITLE
[feature/auto] Add autofill on Auth screen

### DIFF
--- a/feature/authentication/src/main/java/com/alxnophis/jetpack/authentication/ui/view/AuthenticationForm.kt
+++ b/feature/authentication/src/main/java/com/alxnophis/jetpack/authentication/ui/view/AuthenticationForm.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.autofill.AutofillType
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -57,6 +58,7 @@ import com.alxnophis.jetpack.authentication.R
 import com.alxnophis.jetpack.authentication.ui.contract.AuthenticationMode
 import com.alxnophis.jetpack.authentication.ui.contract.PasswordRequirements
 import com.alxnophis.jetpack.core.base.constants.EMPTY
+import com.alxnophis.jetpack.core.ui.composable.autofill
 import com.alxnophis.jetpack.core.ui.theme.CoreTheme
 
 @ExperimentalComposeUiApi
@@ -173,6 +175,7 @@ internal fun AuthenticationTitle(
     )
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun EmailInput(
     modifier: Modifier = Modifier.fillMaxWidth(),
@@ -181,7 +184,11 @@ fun EmailInput(
     onNextClicked: () -> Unit
 ) {
     TextField(
-        modifier = modifier,
+        modifier = modifier
+            .autofill(
+                autofillTypes = listOf(AutofillType.EmailAddress),
+                onFill = { onEmailChanged(it) },
+            ),
         value = email,
         singleLine = true,
         onValueChange = { emailChanged -> onEmailChanged(emailChanged) },
@@ -218,7 +225,11 @@ fun PasswordInput(
     val keyboardController = LocalSoftwareKeyboardController.current
     var isPasswordHidden by remember { mutableStateOf(true) }
     TextField(
-        modifier = modifier,
+        modifier = modifier
+            .autofill(
+                autofillTypes = listOf(AutofillType.Password),
+                onFill = { onPasswordChanged(it) },
+            ),
         value = password,
         singleLine = true,
         onValueChange = { onPasswordChanged(it) },

--- a/shared/core/src/main/java/com/alxnophis/jetpack/core/ui/composable/Autofill.kt
+++ b/shared/core/src/main/java/com/alxnophis/jetpack/core/ui/composable/Autofill.kt
@@ -1,0 +1,36 @@
+package com.alxnophis.jetpack.core.ui.composable
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.autofill.AutofillNode
+import androidx.compose.ui.autofill.AutofillType
+import androidx.compose.ui.composed
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalAutofill
+import androidx.compose.ui.platform.LocalAutofillTree
+
+/**
+ * Autofill with Jetpack Compose
+ * https://bryanherbst.com/2021/04/13/compose-autofill/
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+fun Modifier.autofill(
+    autofillTypes: List<AutofillType>,
+    onFill: ((String) -> Unit),
+) = composed {
+    val autofill = LocalAutofill.current
+    val autofillNode = AutofillNode(onFill = onFill, autofillTypes = autofillTypes)
+    LocalAutofillTree.current += autofillNode
+    onGloballyPositioned { autofillNode.boundingBox = it.boundsInWindow() }
+        .onFocusChanged { focusState ->
+            autofill?.run {
+                if (focusState.isFocused) {
+                    requestAutofillForNode(autofillNode)
+                } else {
+                    cancelAutofillForNode(autofillNode)
+                }
+            }
+        }
+}


### PR DESCRIPTION
### ⚡️ Proposed Changes
* Add autofill using compose on Auth screen

### ℹ️ Additional Info
* Add any additional useful context or info

### 🔗 Related Links
* [Autofill with Jetpack Compose](https://bryanherbst.com/2021/04/13/compose-autofill/)

### ✅ Checklist
- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Compose Tests
- [ ] Maestro Tests
- [ ] Updated string
- [ ] Manually tested

### 📷 Screenshots
