### PR TITLE
[FEATURE] Save the settings securely

### DIFF
--- a/buildSystem/gradle/common-android-base.gradle
+++ b/buildSystem/gradle/common-android-base.gradle
@@ -30,13 +30,13 @@ android {
             debuggable true
             minifyEnabled false
             buildConfigField 'String', 'APP_PACKAGE_NAME', '"' + AppConfig.APP_PACKAGE_NAME_DEBUG + '"'
-            buildConfigField 'String', 'APP_KEY_ALIAS', '"' + AppConfig.APP_PACKAGE_NAME_DEBUG.hashCode() + '"'
+            buildConfigField 'String', 'APP_CRYPTO_KEY_ALIAS', '"' + AppConfig.APP_PACKAGE_NAME_DEBUG.hashCode() + '"'
         }
         release {
             debuggable false
             minifyEnabled false
             buildConfigField 'String', 'APP_PACKAGE_NAME', '"' + AppConfig.APP_PACKAGE_NAME + '"'
-            buildConfigField 'String', 'APP_KEY_ALIAS', '"' + AppConfig.APP_PACKAGE_NAME.hashCode() + '"'
+            buildConfigField 'String', 'APP_CRYPTO_KEY_ALIAS', '"' + AppConfig.APP_PACKAGE_NAME.hashCode() + '"'
         }
     }
 

--- a/buildSystem/gradle/common-android-base.gradle
+++ b/buildSystem/gradle/common-android-base.gradle
@@ -30,11 +30,13 @@ android {
             debuggable true
             minifyEnabled false
             buildConfigField 'String', 'APP_PACKAGE_NAME', '"' + AppConfig.APP_PACKAGE_NAME_DEBUG + '"'
+            buildConfigField 'String', 'APP_KEY_ALIAS', '"' + AppConfig.APP_PACKAGE_NAME_DEBUG.hashCode() + '"'
         }
         release {
             debuggable false
             minifyEnabled false
             buildConfigField 'String', 'APP_PACKAGE_NAME', '"' + AppConfig.APP_PACKAGE_NAME + '"'
+            buildConfigField 'String', 'APP_KEY_ALIAS', '"' + AppConfig.APP_PACKAGE_NAME.hashCode() + '"'
         }
     }
 

--- a/feature/settings/build.gradle
+++ b/feature/settings/build.gradle
@@ -4,3 +4,7 @@ android {
     resourcePrefix 'settings'
     namespace 'com.alxnophis.jetpack.settings'
 }
+
+dependencies {
+    implementation libs.androidx.datastore.preferences
+}

--- a/feature/settings/src/androidTest/java/com/alxnophis/jetpack/settings/ui/composable/SettingsTest.kt
+++ b/feature/settings/src/androidTest/java/com/alxnophis/jetpack/settings/ui/composable/SettingsTest.kt
@@ -14,7 +14,7 @@ import com.alxnophis.jetpack.settings.ui.composable.SettingsTags.TAG_CHECK_ITEM
 import com.alxnophis.jetpack.settings.ui.composable.SettingsTags.TAG_MARKETING_OPTION
 import com.alxnophis.jetpack.settings.ui.composable.SettingsTags.TAG_TOGGLE_ITEM
 import com.alxnophis.jetpack.settings.ui.contract.MarketingOption
-import com.alxnophis.jetpack.settings.ui.contract.SettingsState
+import com.alxnophis.jetpack.settings.ui.contract.SettingsUiState
 import com.alxnophis.jetpack.settings.ui.contract.hintsEnabled
 import com.alxnophis.jetpack.settings.ui.contract.marketingOption
 import com.alxnophis.jetpack.settings.ui.contract.notificationsEnabled
@@ -62,8 +62,8 @@ internal class SettingsTest : BaseComposeTest() {
     fun enabled_notifications_toggles_state() {
         setSettingsContent(
             state =
-                SettingsState.initialState.copy {
-                    SettingsState.notificationsEnabled set true
+                SettingsUiState.initialState.copy {
+                    SettingsUiState.notificationsEnabled set true
                 },
         )
         composeTestRule
@@ -89,8 +89,8 @@ internal class SettingsTest : BaseComposeTest() {
     fun show_hints_enabled() {
         setSettingsContent(
             state =
-                SettingsState.initialState.copy {
-                    SettingsState.hintsEnabled set true
+                SettingsUiState.initialState.copy {
+                    SettingsUiState.hintsEnabled set true
                 },
         )
         composeTestRule
@@ -127,8 +127,8 @@ internal class SettingsTest : BaseComposeTest() {
     fun marketing_options_not_allowed() {
         setSettingsContent(
             state =
-                SettingsState.initialState.copy {
-                    SettingsState.marketingOption set MarketingOption.NOT_ALLOWED
+                SettingsUiState.initialState.copy {
+                    SettingsUiState.marketingOption set MarketingOption.NOT_ALLOWED
                 },
         )
         composeTestRule
@@ -147,7 +147,7 @@ internal class SettingsTest : BaseComposeTest() {
             .assertIsDisplayed()
     }
 
-    private fun setSettingsContent(state: SettingsState = SettingsState.initialState) {
+    private fun setSettingsContent(state: SettingsUiState = SettingsUiState.initialState) {
         composeTestRule.setContent {
             SettingsScreen(
                 state = state,

--- a/feature/settings/src/main/java/com/alxnophis/jetpack/settings/data/model/SettingsPreferences.kt
+++ b/feature/settings/src/main/java/com/alxnophis/jetpack/settings/data/model/SettingsPreferences.kt
@@ -39,6 +39,24 @@ internal data class SettingsPreferences(
     }
 }
 
+/**
+ * Serializer for [SettingsPreferences].
+ *
+ * This serializer handles the reading and writing of [SettingsPreferences] to and from an [InputStream]
+ * and [OutputStream] respectively. The serialization process involves the following steps for security:
+ *
+ * 1. **Serialization to JSON**: The [SettingsPreferences] object is first converted into a JSON string.
+ * 2. **Encryption**: The JSON string (as bytes) is then encrypted using [Crypto].
+ * 3. **Base64 Encoding**: The encrypted bytes are Base64 encoded to ensure safe transmission and storage as a string.
+ *
+ * The deserialization process reverses these steps:
+ *
+ * 1. **Base64 Decoding**: The input string is Base64 decoded.
+ * 2. **Decryption**: The resulting bytes are decrypted using [Crypto].
+ * 3. **Deserialization from JSON**: The decrypted string is parsed from JSON back into a [SettingsPreferences] object.
+ *
+ * Encryption is applied to protect the user's settings data.
+ */
 internal object SettingsPreferencesSerializer : Serializer<SettingsPreferences> {
     override val defaultValue: SettingsPreferences
         get() = SettingsPreferences.default

--- a/feature/settings/src/main/java/com/alxnophis/jetpack/settings/data/model/SettingsPreferences.kt
+++ b/feature/settings/src/main/java/com/alxnophis/jetpack/settings/data/model/SettingsPreferences.kt
@@ -1,0 +1,72 @@
+package com.alxnophis.jetpack.settings.data.model
+
+import androidx.annotation.StringRes
+import androidx.datastore.core.Serializer
+import com.alxnophis.jetpack.core.base.crypto.Crypto
+import com.alxnophis.jetpack.settings.R
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.Base64
+
+@Serializable
+internal data class SettingsPreferences(
+    val notificationsEnabled: Boolean,
+    val hintsEnabled: Boolean,
+    val marketingOption: Boolean,
+    val themeOption: ThemeOptions,
+) {
+    @Serializable
+    internal enum class ThemeOptions(
+        @StringRes val label: Int,
+    ) {
+        LIGHT(R.string.settings_light),
+        DARK(R.string.settings_dark),
+        SYSTEM(R.string.settings_system),
+    }
+
+    companion object {
+        const val FILE_NAME = "settings_preferences"
+        val default =
+            SettingsPreferences(
+                notificationsEnabled = false,
+                hintsEnabled = false,
+                marketingOption = true,
+                themeOption = ThemeOptions.SYSTEM,
+            )
+    }
+}
+
+internal object SettingsPreferencesSerializer : Serializer<SettingsPreferences> {
+    override val defaultValue: SettingsPreferences
+        get() = SettingsPreferences.default
+
+    override suspend fun readFrom(input: InputStream): SettingsPreferences {
+        val encryptedBytes =
+            withContext(Dispatchers.IO) {
+                input.bufferedReader().use { it.readText() }
+            }
+        val encryptedBytesDecoded = Base64.getDecoder().decode(encryptedBytes)
+        val decryptedBytes = Crypto.decrypt(encryptedBytesDecoded)
+        val decodeJsonString = decryptedBytes.decodeToString()
+        return Json.decodeFromString(decodeJsonString)
+    }
+
+    override suspend fun writeTo(
+        t: SettingsPreferences,
+        output: OutputStream,
+    ) {
+        val json = Json.encodeToString(t)
+        val bytes = json.toByteArray()
+        val encryptedBytes = Crypto.encrypt(bytes)
+        val encryptedBytesBase64 = Base64.getEncoder().encode(encryptedBytes)
+        withContext(Dispatchers.IO) {
+            output.use {
+                it.write(encryptedBytesBase64)
+            }
+        }
+    }
+}

--- a/feature/settings/src/main/java/com/alxnophis/jetpack/settings/data/model/SettingsPreferences.kt
+++ b/feature/settings/src/main/java/com/alxnophis/jetpack/settings/data/model/SettingsPreferences.kt
@@ -29,7 +29,6 @@ internal data class SettingsPreferences(
     }
 
     companion object {
-        const val FILE_NAME = "settings_preferences"
         val default =
             SettingsPreferences(
                 notificationsEnabled = false,

--- a/feature/settings/src/main/java/com/alxnophis/jetpack/settings/data/model/SettingsPreferencesError.kt
+++ b/feature/settings/src/main/java/com/alxnophis/jetpack/settings/data/model/SettingsPreferencesError.kt
@@ -1,0 +1,7 @@
+package com.alxnophis.jetpack.settings.data.model
+
+internal sealed class SettingsPreferencesError {
+    data object Disk : SettingsPreferencesError()
+
+    data object Unexpected : SettingsPreferencesError()
+}

--- a/feature/settings/src/main/java/com/alxnophis/jetpack/settings/data/repository/SettingsRepository.kt
+++ b/feature/settings/src/main/java/com/alxnophis/jetpack/settings/data/repository/SettingsRepository.kt
@@ -1,0 +1,17 @@
+package com.alxnophis.jetpack.settings.data.repository
+
+import arrow.core.Either
+import com.alxnophis.jetpack.settings.data.model.SettingsPreferences
+import com.alxnophis.jetpack.settings.data.model.SettingsPreferencesError
+
+internal interface SettingsRepository {
+    suspend fun getSettings(): SettingsPreferences
+
+    suspend fun updateNotificationsEnabled(enabled: Boolean): Either<SettingsPreferencesError, Unit>
+
+    suspend fun updateHintsEnabled(enabled: Boolean): Either<SettingsPreferencesError, Unit>
+
+    suspend fun updateMarketingOption(enabled: Boolean): Either<SettingsPreferencesError, Unit>
+
+    suspend fun updateThemeOption(themeOption: SettingsPreferences.ThemeOptions): Either<SettingsPreferencesError, Unit>
+}

--- a/feature/settings/src/main/java/com/alxnophis/jetpack/settings/data/repository/SettingsRepository.kt
+++ b/feature/settings/src/main/java/com/alxnophis/jetpack/settings/data/repository/SettingsRepository.kt
@@ -3,9 +3,10 @@ package com.alxnophis.jetpack.settings.data.repository
 import arrow.core.Either
 import com.alxnophis.jetpack.settings.data.model.SettingsPreferences
 import com.alxnophis.jetpack.settings.data.model.SettingsPreferencesError
+import kotlinx.coroutines.flow.Flow
 
 internal interface SettingsRepository {
-    suspend fun getSettings(): SettingsPreferences
+    fun getSettingsFlow(): Flow<SettingsPreferences>
 
     suspend fun updateNotificationsEnabled(enabled: Boolean): Either<SettingsPreferencesError, Unit>
 

--- a/feature/settings/src/main/java/com/alxnophis/jetpack/settings/data/repository/SettingsRepositoryImpl.kt
+++ b/feature/settings/src/main/java/com/alxnophis/jetpack/settings/data/repository/SettingsRepositoryImpl.kt
@@ -17,7 +17,7 @@ internal class SettingsRepositoryImpl(
     private val context: Context,
 ) : SettingsRepository {
     private val Context.dataStore: DataStore<SettingsPreferences> by dataStore(
-        fileName = SettingsPreferences.FILE_NAME,
+        fileName = SETTINGS_PREFERENCES_FILE_NAME,
         serializer = SettingsPreferencesSerializer,
     )
 
@@ -47,4 +47,8 @@ internal class SettingsRepositoryImpl(
     override suspend fun updateMarketingOption(enabled: Boolean): Either<SettingsPreferencesError, Unit> = updatePreference { it.copy(marketingOption = enabled) }
 
     override suspend fun updateThemeOption(themeOption: SettingsPreferences.ThemeOptions): Either<SettingsPreferencesError, Unit> = updatePreference { it.copy(themeOption = themeOption) }
+
+    companion object {
+        private const val SETTINGS_PREFERENCES_FILE_NAME = "settings_preferences"
+    }
 }

--- a/feature/settings/src/main/java/com/alxnophis/jetpack/settings/data/repository/SettingsRepositoryImpl.kt
+++ b/feature/settings/src/main/java/com/alxnophis/jetpack/settings/data/repository/SettingsRepositoryImpl.kt
@@ -10,8 +10,6 @@ import com.alxnophis.jetpack.settings.data.model.SettingsPreferences
 import com.alxnophis.jetpack.settings.data.model.SettingsPreferencesError
 import com.alxnophis.jetpack.settings.data.model.SettingsPreferencesSerializer
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.firstOrNull
-import kotlinx.coroutines.flow.map
 
 internal typealias UpdatedSuccessfully = Unit
 
@@ -29,7 +27,7 @@ internal class SettingsRepositoryImpl(
     private val settingsDataStoreData: Flow<SettingsPreferences>
         get() = context.dataStore.data
 
-    override suspend fun getSettings(): SettingsPreferences = settingsDataStoreData.firstOrNull() ?: SettingsPreferences.default
+    override fun getSettingsFlow(): Flow<SettingsPreferences> = settingsDataStoreData
 
     private suspend inline fun updatePreference(crossinline update: (SettingsPreferences) -> SettingsPreferences): Either<SettingsPreferencesError, Unit> =
         catch {

--- a/feature/settings/src/main/java/com/alxnophis/jetpack/settings/data/repository/SettingsRepositoryImpl.kt
+++ b/feature/settings/src/main/java/com/alxnophis/jetpack/settings/data/repository/SettingsRepositoryImpl.kt
@@ -1,0 +1,52 @@
+package com.alxnophis.jetpack.settings.data.repository
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.IOException
+import androidx.datastore.dataStore
+import arrow.core.Either
+import arrow.core.Either.Companion.catch
+import com.alxnophis.jetpack.settings.data.model.SettingsPreferences
+import com.alxnophis.jetpack.settings.data.model.SettingsPreferencesError
+import com.alxnophis.jetpack.settings.data.model.SettingsPreferencesSerializer
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+
+internal typealias UpdatedSuccessfully = Unit
+
+internal class SettingsRepositoryImpl(
+    private val context: Context,
+) : SettingsRepository {
+    private val Context.dataStore: DataStore<SettingsPreferences> by dataStore(
+        fileName = SettingsPreferences.FILE_NAME,
+        serializer = SettingsPreferencesSerializer,
+    )
+
+    private val settingsDataStore: DataStore<SettingsPreferences>
+        get() = context.dataStore
+
+    private val settingsDataStoreData: Flow<SettingsPreferences>
+        get() = context.dataStore.data
+
+    override suspend fun getSettings(): SettingsPreferences = settingsDataStoreData.firstOrNull() ?: SettingsPreferences.default
+
+    private suspend inline fun updatePreference(crossinline update: (SettingsPreferences) -> SettingsPreferences): Either<SettingsPreferencesError, Unit> =
+        catch {
+            settingsDataStore.updateData { update(it) }
+        }.map { UpdatedSuccessfully }
+            .mapLeft { error ->
+                when (error) {
+                    is IOException -> SettingsPreferencesError.Disk
+                    else -> SettingsPreferencesError.Unexpected
+                }
+            }
+
+    override suspend fun updateNotificationsEnabled(enabled: Boolean): Either<SettingsPreferencesError, Unit> = updatePreference { it.copy(notificationsEnabled = enabled) }
+
+    override suspend fun updateHintsEnabled(enabled: Boolean): Either<SettingsPreferencesError, Unit> = updatePreference { it.copy(hintsEnabled = enabled) }
+
+    override suspend fun updateMarketingOption(enabled: Boolean): Either<SettingsPreferencesError, Unit> = updatePreference { it.copy(marketingOption = enabled) }
+
+    override suspend fun updateThemeOption(themeOption: SettingsPreferences.ThemeOptions): Either<SettingsPreferencesError, Unit> = updatePreference { it.copy(themeOption = themeOption) }
+}

--- a/feature/settings/src/main/java/com/alxnophis/jetpack/settings/di/SettingsModule.kt
+++ b/feature/settings/src/main/java/com/alxnophis/jetpack/settings/di/SettingsModule.kt
@@ -18,5 +18,5 @@ private val loadSettingsModule by lazy {
 private val settingsModule: Module =
     module {
         single<SettingsRepository> { SettingsRepositoryImpl(androidContext()) }
-        viewModel { SettingsViewModel() }
+        viewModel { SettingsViewModel(get()) }
     }

--- a/feature/settings/src/main/java/com/alxnophis/jetpack/settings/di/SettingsModule.kt
+++ b/feature/settings/src/main/java/com/alxnophis/jetpack/settings/di/SettingsModule.kt
@@ -1,6 +1,9 @@
 package com.alxnophis.jetpack.settings.di
 
+import com.alxnophis.jetpack.settings.data.repository.SettingsRepository
+import com.alxnophis.jetpack.settings.data.repository.SettingsRepositoryImpl
 import com.alxnophis.jetpack.settings.ui.viewmodel.SettingsViewModel
+import org.koin.android.ext.koin.androidContext
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.core.context.loadKoinModules
 import org.koin.core.module.Module
@@ -14,5 +17,6 @@ private val loadSettingsModule by lazy {
 
 private val settingsModule: Module =
     module {
+        single<SettingsRepository> { SettingsRepositoryImpl(androidContext()) }
         viewModel { SettingsViewModel() }
     }

--- a/feature/settings/src/main/java/com/alxnophis/jetpack/settings/ui/composable/SettingsPreviewProvider.kt
+++ b/feature/settings/src/main/java/com/alxnophis/jetpack/settings/ui/composable/SettingsPreviewProvider.kt
@@ -2,26 +2,26 @@ package com.alxnophis.jetpack.settings.ui.composable
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.alxnophis.jetpack.settings.ui.contract.MarketingOption
-import com.alxnophis.jetpack.settings.ui.contract.SettingsState
+import com.alxnophis.jetpack.settings.ui.contract.SettingsUiState
 import com.alxnophis.jetpack.settings.ui.contract.Theme
 
-internal class SettingsPreviewProvider : PreviewParameterProvider<SettingsState> {
-    override val values: Sequence<SettingsState>
+internal class SettingsPreviewProvider : PreviewParameterProvider<SettingsUiState> {
+    override val values: Sequence<SettingsUiState>
         get() =
             sequenceOf(
-                SettingsState(
+                SettingsUiState(
                     notificationsEnabled = false,
                     hintsEnabled = false,
                     marketingOption = MarketingOption.ALLOWED,
                     themeOption = Theme.SYSTEM,
                 ),
-                SettingsState(
+                SettingsUiState(
                     notificationsEnabled = true,
                     hintsEnabled = true,
                     marketingOption = MarketingOption.NOT_ALLOWED,
                     themeOption = Theme.DARK,
                 ),
-                SettingsState(
+                SettingsUiState(
                     notificationsEnabled = true,
                     hintsEnabled = true,
                     marketingOption = MarketingOption.NOT_ALLOWED,

--- a/feature/settings/src/main/java/com/alxnophis/jetpack/settings/ui/composable/SettingsScreen.kt
+++ b/feature/settings/src/main/java/com/alxnophis/jetpack/settings/ui/composable/SettingsScreen.kt
@@ -24,16 +24,16 @@ import com.alxnophis.jetpack.core.extensions.getVersion
 import com.alxnophis.jetpack.core.ui.composable.CoreTopBar
 import com.alxnophis.jetpack.core.ui.theme.AppTheme
 import com.alxnophis.jetpack.settings.R
-import com.alxnophis.jetpack.settings.ui.contract.SettingsEvent
-import com.alxnophis.jetpack.settings.ui.contract.SettingsState
+import com.alxnophis.jetpack.settings.ui.contract.SettingsUiEvent
+import com.alxnophis.jetpack.settings.ui.contract.SettingsUiState
 
 @Composable
 internal fun SettingsScreen(
-    state: SettingsState,
-    onEvent: (SettingsEvent) -> Unit = {},
+    state: SettingsUiState,
+    onEvent: (SettingsUiEvent) -> Unit = {},
     appVersion: String = LocalContext.current.getVersion(),
 ) {
-    BackHandler { onEvent(SettingsEvent.GoBackRequested) }
+    BackHandler { onEvent(SettingsUiEvent.GoBackRequested) }
     AppTheme {
         val context = LocalContext.current
         Scaffold(
@@ -41,7 +41,7 @@ internal fun SettingsScreen(
                 CoreTopBar(
                     modifier = Modifier.fillMaxWidth(),
                     title = stringResource(id = R.string.settings_title),
-                    onBack = { onEvent(SettingsEvent.GoBackRequested) },
+                    onBack = { onEvent(SettingsUiEvent.GoBackRequested) },
                 )
             },
             modifier = Modifier.fillMaxSize(),
@@ -59,14 +59,14 @@ internal fun SettingsScreen(
                     modifier = Modifier.fillMaxWidth(),
                     title = stringResource(id = R.string.settings_option_notifications),
                     checked = state.notificationsEnabled,
-                    onToggleNotificationSettings = { onEvent(SettingsEvent.SetNotifications) },
+                    onToggleNotificationSettings = { onEvent(SettingsUiEvent.SetNotifications) },
                 )
                 HorizontalDivider()
                 SettingsHintItem(
                     modifier = Modifier.fillMaxWidth(),
                     title = stringResource(id = R.string.settings_option_hints),
                     checked = state.hintsEnabled,
-                    onShowHintToggled = { onEvent(SettingsEvent.SetHint) },
+                    onShowHintToggled = { onEvent(SettingsUiEvent.SetHint) },
                 )
                 HorizontalDivider()
                 SettingsManageSubscriptionItem(
@@ -76,7 +76,7 @@ internal fun SettingsScreen(
                         Toast
                             .makeText(context, R.string.settings_option_manage_subscription, Toast.LENGTH_LONG)
                             .show()
-                        onEvent(SettingsEvent.ManageSubscription)
+                        onEvent(SettingsUiEvent.ManageSubscription)
                     },
                 )
                 HorizontalDivider()
@@ -87,7 +87,7 @@ internal fun SettingsScreen(
                     modifier = Modifier.fillMaxWidth(),
                     selectedOption = state.marketingOption,
                     onOptionSelected = { marketingOption ->
-                        onEvent(SettingsEvent.SetMarketingOption(marketingOption))
+                        onEvent(SettingsUiEvent.SetMarketingOption(marketingOption))
                     },
                 )
                 HorizontalDivider()
@@ -95,7 +95,7 @@ internal fun SettingsScreen(
                     modifier = Modifier.fillMaxWidth(),
                     selectedTheme = state.themeOption,
                     onOptionSelected = { theme ->
-                        onEvent(SettingsEvent.SetTheme(theme))
+                        onEvent(SettingsUiEvent.SetTheme(theme))
                     },
                 )
                 SettingsSectionSpacer(
@@ -114,7 +114,7 @@ internal fun SettingsScreen(
 @Preview(showBackground = true)
 @Composable
 private fun SettingsScreenPreview(
-    @PreviewParameter(SettingsPreviewProvider::class) uiState: SettingsState,
+    @PreviewParameter(SettingsPreviewProvider::class) uiState: SettingsUiState,
 ) {
     SettingsScreen(
         state = uiState,

--- a/feature/settings/src/main/java/com/alxnophis/jetpack/settings/ui/contract/SettingsContract.kt
+++ b/feature/settings/src/main/java/com/alxnophis/jetpack/settings/ui/contract/SettingsContract.kt
@@ -5,6 +5,7 @@ import arrow.optics.optics
 import com.alxnophis.jetpack.core.ui.viewmodel.UiEvent
 import com.alxnophis.jetpack.core.ui.viewmodel.UiState
 import com.alxnophis.jetpack.settings.R
+import com.alxnophis.jetpack.settings.data.model.SettingsPreferences
 
 internal sealed class SettingsEvent : UiEvent {
     data object ManageSubscription : SettingsEvent()
@@ -55,4 +56,12 @@ internal enum class Theme(
     LIGHT(R.string.settings_light),
     DARK(R.string.settings_dark),
     SYSTEM(R.string.settings_system),
+    ;
+
+    fun map(): SettingsPreferences.ThemeOptions =
+        when (this) {
+            LIGHT -> SettingsPreferences.ThemeOptions.LIGHT
+            DARK -> SettingsPreferences.ThemeOptions.DARK
+            SYSTEM -> SettingsPreferences.ThemeOptions.SYSTEM
+        }
 }

--- a/feature/settings/src/main/java/com/alxnophis/jetpack/settings/ui/contract/SettingsContract.kt
+++ b/feature/settings/src/main/java/com/alxnophis/jetpack/settings/ui/contract/SettingsContract.kt
@@ -7,26 +7,26 @@ import com.alxnophis.jetpack.core.ui.viewmodel.UiState
 import com.alxnophis.jetpack.settings.R
 import com.alxnophis.jetpack.settings.data.model.SettingsPreferences
 
-internal sealed class SettingsEvent : UiEvent {
-    data object ManageSubscription : SettingsEvent()
+internal sealed class SettingsUiEvent : UiEvent {
+    data object ManageSubscription : SettingsUiEvent()
 
-    data object SetNotifications : SettingsEvent()
+    data object SetNotifications : SettingsUiEvent()
 
-    data object SetHint : SettingsEvent()
+    data object SetHint : SettingsUiEvent()
 
-    data object GoBackRequested : SettingsEvent()
+    data object GoBackRequested : SettingsUiEvent()
 
     data class SetMarketingOption(
         val marketingOption: MarketingOption,
-    ) : SettingsEvent()
+    ) : SettingsUiEvent()
 
     data class SetTheme(
         val theme: Theme,
-    ) : SettingsEvent()
+    ) : SettingsUiEvent()
 }
 
 @optics
-internal data class SettingsState(
+internal data class SettingsUiState(
     val notificationsEnabled: Boolean,
     val hintsEnabled: Boolean,
     val marketingOption: MarketingOption,
@@ -34,10 +34,10 @@ internal data class SettingsState(
 ) : UiState {
     internal companion object {
         val initialState =
-            SettingsState(
+            SettingsUiState(
                 notificationsEnabled = false,
                 hintsEnabled = false,
-                marketingOption = MarketingOption.ALLOWED,
+                marketingOption = MarketingOption.NOT_ALLOWED,
                 themeOption = Theme.SYSTEM,
             )
     }

--- a/feature/settings/src/main/java/com/alxnophis/jetpack/settings/ui/mapper/SettingsPreferencesMapper.kt
+++ b/feature/settings/src/main/java/com/alxnophis/jetpack/settings/ui/mapper/SettingsPreferencesMapper.kt
@@ -1,0 +1,11 @@
+package com.alxnophis.jetpack.settings.ui.mapper
+
+import com.alxnophis.jetpack.settings.data.model.SettingsPreferences
+import com.alxnophis.jetpack.settings.ui.contract.Theme
+
+internal fun SettingsPreferences.ThemeOptions.map(): Theme =
+    when (this) {
+        SettingsPreferences.ThemeOptions.LIGHT -> Theme.LIGHT
+        SettingsPreferences.ThemeOptions.DARK -> Theme.DARK
+        SettingsPreferences.ThemeOptions.SYSTEM -> Theme.SYSTEM
+    }

--- a/feature/settings/src/main/java/com/alxnophis/jetpack/settings/ui/navigation/SettingsNavGraph.kt
+++ b/feature/settings/src/main/java/com/alxnophis/jetpack/settings/ui/navigation/SettingsNavGraph.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.alxnophis.jetpack.settings.di.injectSettings
 import com.alxnophis.jetpack.settings.ui.composable.SettingsScreen
-import com.alxnophis.jetpack.settings.ui.contract.SettingsEvent
+import com.alxnophis.jetpack.settings.ui.contract.SettingsUiEvent
 import com.alxnophis.jetpack.settings.ui.viewmodel.SettingsViewModel
 import org.koin.androidx.compose.getViewModel
 
@@ -16,7 +16,7 @@ fun SettingsFeature(onBack: () -> Unit) {
         state = viewModel.uiState.collectAsStateWithLifecycle().value,
         onEvent = { event ->
             when (event) {
-                SettingsEvent.GoBackRequested -> onBack()
+                SettingsUiEvent.GoBackRequested -> onBack()
                 else -> viewModel.handleEvent(event)
             }
         },

--- a/feature/settings/src/main/java/com/alxnophis/jetpack/settings/ui/viewmodel/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/alxnophis/jetpack/settings/ui/viewmodel/SettingsViewModel.kt
@@ -1,54 +1,59 @@
 package com.alxnophis.jetpack.settings.ui.viewmodel
 
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import arrow.optics.updateCopy
 import com.alxnophis.jetpack.core.extensions.doNothing
-import com.alxnophis.jetpack.core.ui.viewmodel.BaseViewModel
 import com.alxnophis.jetpack.settings.data.repository.SettingsRepository
 import com.alxnophis.jetpack.settings.ui.contract.MarketingOption
-import com.alxnophis.jetpack.settings.ui.contract.SettingsEvent
-import com.alxnophis.jetpack.settings.ui.contract.SettingsState
+import com.alxnophis.jetpack.settings.ui.contract.SettingsUiEvent
+import com.alxnophis.jetpack.settings.ui.contract.SettingsUiState
 import com.alxnophis.jetpack.settings.ui.contract.Theme
-import com.alxnophis.jetpack.settings.ui.contract.hintsEnabled
-import com.alxnophis.jetpack.settings.ui.contract.marketingOption
-import com.alxnophis.jetpack.settings.ui.contract.notificationsEnabled
-import com.alxnophis.jetpack.settings.ui.contract.themeOption
 import com.alxnophis.jetpack.settings.ui.mapper.map
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 internal class SettingsViewModel(
     private val settingsRepository: SettingsRepository,
-    initialState: SettingsState = SettingsState.initialState,
-) : BaseViewModel<SettingsEvent, SettingsState>(initialState) {
-    init {
-        restoreState()
-    }
+    initialState: SettingsUiState = SettingsUiState.initialState,
+) : ViewModel() {
+    private val currentState: SettingsUiState
+        get() = uiState.value
 
-    private fun restoreState() {
-        viewModelScope.launch {
-            val settings = settingsRepository.getSettings()
-            _uiState.updateCopy {
-                SettingsState.notificationsEnabled set settings.notificationsEnabled
-                SettingsState.hintsEnabled set settings.hintsEnabled
-                SettingsState.marketingOption set
-                    when (settings.marketingOption) {
-                        true -> MarketingOption.ALLOWED
-                        false -> MarketingOption.NOT_ALLOWED
-                    }
-                SettingsState.themeOption set settings.themeOption.map()
-            }
-        }
-    }
+    val uiState =
+        settingsRepository
+            .getSettingsFlow()
+            .map {
+                SettingsUiState(
+                    notificationsEnabled = it.notificationsEnabled,
+                    hintsEnabled = it.hintsEnabled,
+                    marketingOption =
+                        when (it.marketingOption) {
+                            true -> MarketingOption.ALLOWED
+                            false -> MarketingOption.NOT_ALLOWED
+                        },
+                    themeOption = it.themeOption.map(),
+                )
+            }.stateIn(
+                scope = viewModelScope,
+                initialValue = initialState,
+                started =
+                    SharingStarted.WhileSubscribed(
+                        stopTimeoutMillis = STOP_TIMEOUT_MILLIS,
+                        replayExpirationMillis = REPLAY_EXPIRATION_MILLIS,
+                    ),
+            )
 
-    override fun handleEvent(event: SettingsEvent) {
+    fun handleEvent(event: SettingsUiEvent) {
         viewModelScope.launch {
             when (event) {
-                SettingsEvent.ManageSubscription -> manageSubscription()
-                SettingsEvent.SetNotifications -> toggleNotifications()
-                SettingsEvent.SetHint -> toggleHint()
-                SettingsEvent.GoBackRequested -> throw IllegalStateException("Go back is not implemented")
-                is SettingsEvent.SetMarketingOption -> setMarketing(event.marketingOption)
-                is SettingsEvent.SetTheme -> setTheme(event.theme)
+                SettingsUiEvent.ManageSubscription -> manageSubscription()
+                SettingsUiEvent.SetNotifications -> toggleNotifications()
+                SettingsUiEvent.SetHint -> toggleHint()
+                SettingsUiEvent.GoBackRequested -> throw IllegalStateException("Go back is not implemented")
+                is SettingsUiEvent.SetMarketingOption -> setMarketing(event.marketingOption)
+                is SettingsUiEvent.SetTheme -> setTheme(event.theme)
             }
         }
     }
@@ -57,44 +62,29 @@ internal class SettingsViewModel(
         doNothing()
     }
 
-    private fun toggleNotifications() {
-        _uiState.updateCopy {
-            SettingsState.notificationsEnabled transform { !it }
-        }
-        viewModelScope.launch {
-            settingsRepository.updateNotificationsEnabled(currentState.notificationsEnabled)
-        }
+    private suspend fun toggleNotifications() {
+        settingsRepository.updateNotificationsEnabled(currentState.notificationsEnabled.not())
     }
 
-    private fun toggleHint() {
-        _uiState.updateCopy {
-            SettingsState.hintsEnabled transform { !it }
-        }
-        viewModelScope.launch {
-            settingsRepository.updateHintsEnabled(currentState.hintsEnabled)
-        }
+    private suspend fun toggleHint() {
+        settingsRepository.updateHintsEnabled(currentState.hintsEnabled.not())
     }
 
-    private fun setMarketing(option: MarketingOption) {
-        _uiState.updateCopy {
-            SettingsState.marketingOption set option
-        }
-        viewModelScope.launch {
-            val isMarketingEnabled =
-                when (option) {
-                    MarketingOption.ALLOWED -> true
-                    MarketingOption.NOT_ALLOWED -> false
-                }
-            settingsRepository.updateMarketingOption(isMarketingEnabled)
-        }
+    private suspend fun setMarketing(option: MarketingOption) {
+        val isMarketingEnabled =
+            when (option) {
+                MarketingOption.ALLOWED -> true
+                MarketingOption.NOT_ALLOWED -> false
+            }
+        settingsRepository.updateMarketingOption(isMarketingEnabled)
     }
 
-    private fun setTheme(theme: Theme) {
-        _uiState.updateCopy {
-            SettingsState.themeOption set theme
-        }
-        viewModelScope.launch {
-            settingsRepository.updateThemeOption(theme.map())
-        }
+    private suspend fun setTheme(theme: Theme) {
+        settingsRepository.updateThemeOption(theme.map())
+    }
+
+    companion object {
+        private const val STOP_TIMEOUT_MILLIS = 1_000L
+        private const val REPLAY_EXPIRATION_MILLIS = 9_000L
     }
 }

--- a/feature/settings/src/main/java/com/alxnophis/jetpack/settings/ui/viewmodel/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/alxnophis/jetpack/settings/ui/viewmodel/SettingsViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.viewModelScope
 import arrow.optics.updateCopy
 import com.alxnophis.jetpack.core.extensions.doNothing
 import com.alxnophis.jetpack.core.ui.viewmodel.BaseViewModel
+import com.alxnophis.jetpack.settings.data.repository.SettingsRepository
 import com.alxnophis.jetpack.settings.ui.contract.MarketingOption
 import com.alxnophis.jetpack.settings.ui.contract.SettingsEvent
 import com.alxnophis.jetpack.settings.ui.contract.SettingsState
@@ -12,11 +13,33 @@ import com.alxnophis.jetpack.settings.ui.contract.hintsEnabled
 import com.alxnophis.jetpack.settings.ui.contract.marketingOption
 import com.alxnophis.jetpack.settings.ui.contract.notificationsEnabled
 import com.alxnophis.jetpack.settings.ui.contract.themeOption
+import com.alxnophis.jetpack.settings.ui.mapper.map
 import kotlinx.coroutines.launch
 
 internal class SettingsViewModel(
+    private val settingsRepository: SettingsRepository,
     initialState: SettingsState = SettingsState.initialState,
 ) : BaseViewModel<SettingsEvent, SettingsState>(initialState) {
+    init {
+        restoreState()
+    }
+
+    private fun restoreState() {
+        viewModelScope.launch {
+            val settings = settingsRepository.getSettings()
+            _uiState.updateCopy {
+                SettingsState.notificationsEnabled set settings.notificationsEnabled
+                SettingsState.hintsEnabled set settings.hintsEnabled
+                SettingsState.marketingOption set
+                    when (settings.marketingOption) {
+                        true -> MarketingOption.ALLOWED
+                        false -> MarketingOption.NOT_ALLOWED
+                    }
+                SettingsState.themeOption set settings.themeOption.map()
+            }
+        }
+    }
+
     override fun handleEvent(event: SettingsEvent) {
         viewModelScope.launch {
             when (event) {
@@ -38,11 +61,17 @@ internal class SettingsViewModel(
         _uiState.updateCopy {
             SettingsState.notificationsEnabled transform { !it }
         }
+        viewModelScope.launch {
+            settingsRepository.updateNotificationsEnabled(currentState.notificationsEnabled)
+        }
     }
 
     private fun toggleHint() {
         _uiState.updateCopy {
             SettingsState.hintsEnabled transform { !it }
+        }
+        viewModelScope.launch {
+            settingsRepository.updateHintsEnabled(currentState.hintsEnabled)
         }
     }
 
@@ -50,11 +79,22 @@ internal class SettingsViewModel(
         _uiState.updateCopy {
             SettingsState.marketingOption set option
         }
+        viewModelScope.launch {
+            val isMarketingEnabled =
+                when (option) {
+                    MarketingOption.ALLOWED -> true
+                    MarketingOption.NOT_ALLOWED -> false
+                }
+            settingsRepository.updateMarketingOption(isMarketingEnabled)
+        }
     }
 
     private fun setTheme(theme: Theme) {
         _uiState.updateCopy {
             SettingsState.themeOption set theme
+        }
+        viewModelScope.launch {
+            settingsRepository.updateThemeOption(theme.map())
         }
     }
 }

--- a/feature/settings/src/screenshotTest/kotlin/com/alxnophis/jetpack/posts/ui/composable/SettingsPreviewScreenshot.kt
+++ b/feature/settings/src/screenshotTest/kotlin/com/alxnophis/jetpack/posts/ui/composable/SettingsPreviewScreenshot.kt
@@ -5,12 +5,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.alxnophis.jetpack.settings.ui.composable.SettingsPreviewProvider
 import com.alxnophis.jetpack.settings.ui.composable.SettingsScreen
-import com.alxnophis.jetpack.settings.ui.contract.SettingsState
+import com.alxnophis.jetpack.settings.ui.contract.SettingsUiState
 
 @Preview(showBackground = true)
 @Composable
 private fun SettingsScreenPreview(
-    @PreviewParameter(SettingsPreviewProvider::class) uiState: SettingsState,
+    @PreviewParameter(SettingsPreviewProvider::class) uiState: SettingsUiState,
 ) {
     SettingsScreen(
         state = uiState,

--- a/feature/settings/src/test/java/com/alxnophis/jetpack/settings/data/model/SettingsPreferencesMother.kt
+++ b/feature/settings/src/test/java/com/alxnophis/jetpack/settings/data/model/SettingsPreferencesMother.kt
@@ -1,0 +1,17 @@
+package com.alxnophis.jetpack.settings.data.model
+
+import com.alxnophis.jetpack.settings.data.model.SettingsPreferences.ThemeOptions
+
+internal object SettingsPreferencesMother {
+    fun create(
+        notificationsEnabled: Boolean = false,
+        hintsEnabled: Boolean = false,
+        marketingOption: Boolean = false,
+        themeOption: ThemeOptions = ThemeOptions.SYSTEM,
+    ) = SettingsPreferences(
+        notificationsEnabled = notificationsEnabled,
+        hintsEnabled = hintsEnabled,
+        marketingOption = marketingOption,
+        themeOption = themeOption,
+    )
+}

--- a/feature/settings/src/test/java/com/alxnophis/jetpack/settings/viewmodel/SettingsViewModelUnitTests.kt
+++ b/feature/settings/src/test/java/com/alxnophis/jetpack/settings/viewmodel/SettingsViewModelUnitTests.kt
@@ -1,66 +1,126 @@
 package com.alxnophis.jetpack.settings.viewmodel
 
 import app.cash.turbine.test
+import arrow.core.right
+import com.alxnophis.jetpack.settings.data.model.SettingsPreferences
+import com.alxnophis.jetpack.settings.data.model.SettingsPreferencesMother
+import com.alxnophis.jetpack.settings.data.repository.SettingsRepository
 import com.alxnophis.jetpack.settings.ui.contract.MarketingOption
-import com.alxnophis.jetpack.settings.ui.contract.SettingsEvent
-import com.alxnophis.jetpack.settings.ui.contract.SettingsState
+import com.alxnophis.jetpack.settings.ui.contract.SettingsUiEvent
+import com.alxnophis.jetpack.settings.ui.contract.SettingsUiState
 import com.alxnophis.jetpack.settings.ui.contract.Theme
 import com.alxnophis.jetpack.settings.ui.viewmodel.SettingsViewModel
 import com.alxnophis.jetpack.testing.base.BaseUnitTest
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.MethodSource
-import java.util.stream.Stream
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 @ExperimentalCoroutinesApi
 private class SettingsViewModelUnitTests : BaseUnitTest() {
-    @ParameterizedTest
-    @MethodSource("testProvider")
-    fun `WHEN event THEN assert state change`(
-        event: SettingsEvent,
-        state: SettingsState,
-    ) {
-        runTest {
-            val viewModel = SettingsViewModel(initialState = SettingsState.initialState)
+    private val settingsRepositoryMock: SettingsRepository = mock()
 
-            viewModel.handleEvent(event)
+    @Test
+    fun `GIVEN a user requests settings WHEN initialize viewmodel THEN assert UiState updates`() {
+        runTest {
+            val settingsPreferencesFlow =
+                flowOf(
+                    SettingsPreferencesMother.create(
+                        notificationsEnabled = true,
+                        hintsEnabled = true,
+                        marketingOption = true,
+                        themeOption = SettingsPreferences.ThemeOptions.DARK,
+                    ),
+                )
+            whenever(settingsRepositoryMock.getSettingsFlow()).thenReturn(settingsPreferencesFlow)
+
+            val viewModel = settingsViewModelMother()
 
             viewModel.uiState.test {
-                awaitItem() shouldBeEqualTo initialSettingsState
-                awaitItem() shouldBeEqualTo state
+                awaitItem() shouldBeEqualTo SettingsUiState.initialState
+                awaitItem() shouldBeEqualTo
+                    SettingsUiState(
+                        notificationsEnabled = true,
+                        hintsEnabled = true,
+                        marketingOption = MarketingOption.ALLOWED,
+                        themeOption = Theme.DARK,
+                    )
             }
+
+            verify(settingsRepositoryMock).getSettingsFlow()
         }
     }
 
-    companion object {
-        private val initialSettingsState = SettingsState.initialState
+    @Test
+    fun `GIVEN a user updates notification settings WHEN SetNotifications event THEN assert state change`() {
+        runTest {
+            val viewModel = settingsViewModelMother()
+            val settingsPreferencesFlow = flowOf(SettingsPreferencesMother.create())
+            whenever(settingsRepositoryMock.getSettingsFlow()).thenReturn(settingsPreferencesFlow)
+            whenever(settingsRepositoryMock.updateNotificationsEnabled(true)).thenReturn(Unit.right())
 
-        @JvmStatic
-        private fun testProvider(): Stream<Arguments> =
-            Stream.of(
-                Arguments.of(
-                    SettingsEvent.SetNotifications,
-                    initialSettingsState.copy(notificationsEnabled = !initialSettingsState.notificationsEnabled),
-                ),
-                Arguments.of(
-                    SettingsEvent.SetHint,
-                    initialSettingsState.copy(hintsEnabled = !initialSettingsState.hintsEnabled),
-                ),
-                Arguments.of(
-                    SettingsEvent.SetMarketingOption(MarketingOption.NOT_ALLOWED),
-                    initialSettingsState.copy(marketingOption = MarketingOption.NOT_ALLOWED),
-                ),
-                Arguments.of(
-                    SettingsEvent.SetTheme(Theme.LIGHT),
-                    initialSettingsState.copy(themeOption = Theme.LIGHT),
-                ),
-                Arguments.of(
-                    SettingsEvent.SetTheme(Theme.DARK),
-                    initialSettingsState.copy(themeOption = Theme.DARK),
-                ),
-            )
+            viewModel.handleEvent(SettingsUiEvent.SetNotifications)
+            runCurrent()
+
+            verify(settingsRepositoryMock).updateNotificationsEnabled(true)
+        }
     }
+
+    @Test
+    fun `GIVEN a user updates hint settings WHEN SetHint event THEN assert state change`() {
+        runTest {
+            val viewModel = settingsViewModelMother()
+            val settingsPreferencesFlow = flowOf(SettingsPreferencesMother.create())
+            whenever(settingsRepositoryMock.getSettingsFlow()).thenReturn(settingsPreferencesFlow)
+            whenever(settingsRepositoryMock.updateHintsEnabled(true)).thenReturn(Unit.right())
+
+            viewModel.handleEvent(SettingsUiEvent.SetHint)
+            runCurrent()
+
+            verify(settingsRepositoryMock).updateHintsEnabled(true)
+        }
+    }
+
+    @Test
+    fun `GIVEN a user updates marketing option WHEN SetMarketingOption event THEN assert state change`() {
+        runTest {
+            val viewModel = settingsViewModelMother()
+            val settingsPreferencesFlow = flowOf(SettingsPreferencesMother.create())
+            whenever(settingsRepositoryMock.getSettingsFlow()).thenReturn(settingsPreferencesFlow)
+            whenever(settingsRepositoryMock.updateMarketingOption(true)).thenReturn(Unit.right())
+
+            viewModel.handleEvent(SettingsUiEvent.SetMarketingOption(MarketingOption.ALLOWED))
+            runCurrent()
+
+            verify(settingsRepositoryMock).updateMarketingOption(true)
+        }
+    }
+
+    @Test
+    fun `GIVEN a user updates theme option WHEN SetTheme event THEN assert state change`() {
+        runTest {
+            val viewModel = settingsViewModelMother()
+            val settingsPreferencesFlow = flowOf(SettingsPreferencesMother.create())
+            whenever(settingsRepositoryMock.getSettingsFlow()).thenReturn(settingsPreferencesFlow)
+            whenever(settingsRepositoryMock.updateThemeOption(SettingsPreferences.ThemeOptions.DARK)).thenReturn(Unit.right())
+
+            viewModel.handleEvent(SettingsUiEvent.SetTheme(Theme.DARK))
+            runCurrent()
+
+            verify(settingsRepositoryMock).updateThemeOption(SettingsPreferences.ThemeOptions.DARK)
+        }
+    }
+
+    private fun settingsViewModelMother(
+        settingsRepository: SettingsRepository = settingsRepositoryMock,
+        initialState: SettingsUiState = SettingsUiState.initialState,
+    ) = SettingsViewModel(
+        settingsRepository = settingsRepository,
+        initialState = initialState,
+    )
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,9 +34,9 @@ koin-test = "3.3.3"
 kotlin = "2.1.10"
 kotlinx-collections-immutable = "0.3.5"
 kotlinx-coroutines = "1.7.3"
+kotlinx-serialization-json = "1.8.1"
 kover = "0.6.1"
 ktlint-gradle = "12.1.1"
-kotlinx-serialization-json = "1.8.1"
 leak-canary = "2.10"
 mockito-kotlin = "4.1.0"
 okhttp-profiler = "1.0.8"
@@ -93,6 +93,8 @@ arrow-optics-compose = { module = "io.arrow-kt:arrow-optics-compose" }
 arrow-optics-ksp-plugin = { module = "io.arrow-kt:arrow-optics-ksp-plugin", version.ref = "arrow-stack" }
 arrow-retrofit = { module = "io.arrow-kt:arrow-core-retrofit" }
 arrow-stack = { module = "io.arrow-kt:arrow-stack", version.ref = "arrow-stack" }
+chucker = { module = "com.github.chuckerteam.chucker:library", version.ref = "chucker" }
+chucker-release = { module = "com.github.chuckerteam.chucker:library-no-op", version.ref = "chucker" }
 coil = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 google-android-material = { module = "com.google.android.material:material", version.ref = "google-android-material" }
 google-play-services-location = { module = "com.google.android.gms:play-services-location", version.ref = "google-play-services-location" }
@@ -101,14 +103,13 @@ junit-bom = { module = "org.junit:junit-bom", version.ref = "junit_bom" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params" }
-junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine" }
 kluent = { module = "org.amshove.kluent:kluent-android", version.ref = "kluent" }
 kluent-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin-android" }
 koin-android-compose = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koin-android-compose" }
 koin-android-work-manager = { module = "io.insert-koin:koin-androidx-workmanager", version.ref = "koin-android-work-manager" }
-kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 koin-test = { module = "io.insert-koin:koin-test", version.ref = "koin-test" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect" }
@@ -116,6 +117,7 @@ kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotlinx-collec
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 kover = { module = "org.jetbrains.kotlinx:kover", version.ref = "kover" }
 ktlint-gradle = { module = "org.jlleitschuh.gradle:ktlint-gradle", version.ref = "ktlint-gradle" }
 leak-canary = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leak-canary" }
@@ -131,8 +133,6 @@ retrofit-converter-kotlin_serialization = { module = "com.squareup.retrofit2:con
 slack-lint-compose = { module = "com.slack.lint.compose:compose-lint-checks", version.ref = "slack-lint-compose" }
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
-chucker = { module = "com.github.chuckerteam.chucker:library", version.ref = "chucker" }
-chucker-release = { module = "com.github.chuckerteam.chucker:library-no-op", version.ref = "chucker" }
 
 [bundles]
 androidx-compose = [
@@ -169,8 +169,8 @@ retrofit = [
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }
-android-compose-screenshot = { id = "com.android.compose.screenshot", version.ref = "android-compose-screenshot" }
 android-compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+android-compose-screenshot = { id = "com.android.compose.screenshot", version.ref = "android-compose-screenshot" }
 ben-manes-versions = "com.github.ben-manes.versions:0.46.0"
 google-ksp = "com.google.devtools.ksp:2.1.10-1.0.30"
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ androidx-compose-constraint-layout = "1.1.1"
 androidx-compose-navigation = "2.9.0"
 androidx-compose-viewmodel = "2.9.0"
 androidx-core-ktx = "1.16.0"
+androidx-datastore = "1.1.7"
 androidx-lifecycle = "2.9.0"
 androidx-lifecycle-extension = "2.2.0"
 androidx-test-junit = "1.2.1"
@@ -76,6 +77,7 @@ androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling
 androidx-compose-ui-util = { module = "androidx.compose.ui:ui-util" }
 androidx-compose-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-compose-viewmodel" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core-ktx" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "androidx-datastore" }
 androidx-lifecycle-common = { module = "androidx.lifecycle:lifecycle-common-java8", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-compiler = { module = "androidx.lifecycle:lifecycle-compiler", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-extension = { module = "androidx.lifecycle:lifecycle-extensions", version.ref = "androidx-lifecycle-extension" }

--- a/shared/core/src/main/java/com/alxnophis/jetpack/core/base/crypto/Crypto.kt
+++ b/shared/core/src/main/java/com/alxnophis/jetpack/core/base/crypto/Crypto.kt
@@ -1,0 +1,62 @@
+package com.alxnophis.jetpack.core.base.crypto
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import com.alxnophis.jetpack.kotlin.constants.ZERO_INT
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.IvParameterSpec
+
+object Crypto {
+    private const val KEY_ALIAS = "secret"
+    private const val ALGORITHM = KeyProperties.KEY_ALGORITHM_AES
+    private const val BLOCK_MODE = KeyProperties.BLOCK_MODE_CBC
+    private const val PADDING = KeyProperties.ENCRYPTION_PADDING_PKCS7
+    private const val TRANSFORMATION = "$ALGORITHM/$BLOCK_MODE/$PADDING"
+
+    private val cipher = Cipher.getInstance(TRANSFORMATION)
+    private val keyStore =
+        KeyStore
+            .getInstance("AndroidKeyStore")
+            .apply { load(null) }
+
+    private fun getKey(): SecretKey =
+        if (keyStore.containsAlias(KEY_ALIAS)) {
+            keyStore.getKey(KEY_ALIAS, null) as SecretKey
+        } else {
+            createKey()
+        }
+
+    private fun createKey(): SecretKey =
+        KeyGenerator
+            .getInstance(ALGORITHM)
+            .apply {
+                init(
+                    KeyGenParameterSpec
+                        .Builder(
+                            KEY_ALIAS,
+                            KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+                        ).setBlockModes(BLOCK_MODE)
+                        .setEncryptionPaddings(PADDING)
+                        .setRandomizedEncryptionRequired(true)
+                        .setUserAuthenticationRequired(false)
+                        .build(),
+                )
+            }.generateKey()
+
+    fun encrypt(bytes: ByteArray): ByteArray {
+        cipher.init(Cipher.ENCRYPT_MODE, getKey())
+        val iv = cipher.iv
+        val encryptedData = cipher.doFinal(bytes)
+        return iv + encryptedData
+    }
+
+    fun decrypt(bytes: ByteArray): ByteArray {
+        val iv = bytes.copyOfRange(ZERO_INT, cipher.blockSize)
+        val data = bytes.copyOfRange(cipher.blockSize, bytes.size)
+        cipher.init(Cipher.DECRYPT_MODE, getKey(), IvParameterSpec(iv))
+        return cipher.doFinal(data)
+    }
+}

--- a/shared/core/src/main/java/com/alxnophis/jetpack/core/base/crypto/Crypto.kt
+++ b/shared/core/src/main/java/com/alxnophis/jetpack/core/base/crypto/Crypto.kt
@@ -11,7 +11,7 @@ import javax.crypto.SecretKey
 import javax.crypto.spec.IvParameterSpec
 
 object Crypto {
-    private const val KEY_ALIAS = BuildConfig.APP_KEY_ALIAS
+    private const val KEY_ALIAS = BuildConfig.APP_CRYPTO_KEY_ALIAS
     private const val ALGORITHM = KeyProperties.KEY_ALGORITHM_AES
     private const val BLOCK_MODE = KeyProperties.BLOCK_MODE_CBC
     private const val PADDING = KeyProperties.ENCRYPTION_PADDING_PKCS7

--- a/shared/core/src/main/java/com/alxnophis/jetpack/core/base/crypto/Crypto.kt
+++ b/shared/core/src/main/java/com/alxnophis/jetpack/core/base/crypto/Crypto.kt
@@ -2,6 +2,7 @@ package com.alxnophis.jetpack.core.base.crypto
 
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
+import com.alxnophis.jetpack.core.BuildConfig
 import com.alxnophis.jetpack.kotlin.constants.ZERO_INT
 import java.security.KeyStore
 import javax.crypto.Cipher
@@ -10,13 +11,12 @@ import javax.crypto.SecretKey
 import javax.crypto.spec.IvParameterSpec
 
 object Crypto {
-    private const val KEY_ALIAS = "secret"
+    private const val KEY_ALIAS = BuildConfig.APP_KEY_ALIAS
     private const val ALGORITHM = KeyProperties.KEY_ALGORITHM_AES
     private const val BLOCK_MODE = KeyProperties.BLOCK_MODE_CBC
     private const val PADDING = KeyProperties.ENCRYPTION_PADDING_PKCS7
     private const val TRANSFORMATION = "$ALGORITHM/$BLOCK_MODE/$PADDING"
 
-    private val cipher = Cipher.getInstance(TRANSFORMATION)
     private val keyStore =
         KeyStore
             .getInstance("AndroidKeyStore")
@@ -47,6 +47,7 @@ object Crypto {
             }.generateKey()
 
     fun encrypt(bytes: ByteArray): ByteArray {
+        val cipher = Cipher.getInstance(TRANSFORMATION)
         cipher.init(Cipher.ENCRYPT_MODE, getKey())
         val iv = cipher.iv
         val encryptedData = cipher.doFinal(bytes)
@@ -54,6 +55,7 @@ object Crypto {
     }
 
     fun decrypt(bytes: ByteArray): ByteArray {
+        val cipher = Cipher.getInstance(TRANSFORMATION)
         val iv = bytes.copyOfRange(ZERO_INT, cipher.blockSize)
         val data = bytes.copyOfRange(cipher.blockSize, bytes.size)
         cipher.init(Cipher.DECRYPT_MODE, getKey(), IvParameterSpec(iv))


### PR DESCRIPTION
### ⚡️ Proposed Changes

This pull request introduces significant updates to the `feature/settings` module, including the addition of a robust data layer for managing user preferences, refactoring of UI state and event handling, and integration of new dependencies. The most important changes are grouped below by theme.

### Data Layer Enhancements:
* Added `SettingsPreferences` data model with serialization and encryption capabilities for secure storage and transmission of user settings. (`feature/settings/src/main/java/com/alxnophis/jetpack/settings/data/model/SettingsPreferences.kt`)
* Introduced `SettingsRepository` interface and its implementation (`SettingsRepositoryImpl`) to manage user settings using Android DataStore. (`feature/settings/src/main/java/com/alxnophis/jetpack/settings/data/repository/SettingsRepository.kt`, `feature/settings/src/main/java/com/alxnophis/jetpack/settings/data/repository/SettingsRepositoryImpl.kt`) [[1]](diffhunk://#diff-eb36abf1fe69233550fc477845d835296f3f2098824e57d4b79a7ffe76aa520fR1-R18) [[2]](diffhunk://#diff-ac2bb4c8d5846bdd06f43c8de165608e259658ba3b51209e24cca90c4a13d5b6R1-R54)
* Added error handling for data layer operations with a sealed class `SettingsPreferencesError`. (`feature/settings/src/main/java/com/alxnophis/jetpack/settings/data/model/SettingsPreferencesError.kt`)

### Dependency and DI Updates:
* Integrated `androidx.datastore.preferences` library for managing user preferences. (`feature/settings/build.gradle`)
* Updated Koin DI module to provide `SettingsRepository` and inject it into `SettingsViewModel`. (`feature/settings/src/main/java/com/alxnophis/jetpack/settings/di/SettingsModule.kt`)

### UI State Refactoring:
* Refactored `SettingsState` to `SettingsUiState` and `SettingsEvent` to `SettingsUiEvent` for improved clarity and alignment with the new data layer. (`feature/settings/src/main/java/com/alxnophis/jetpack/settings/ui/contract/SettingsContract.kt`)
* Updated `SettingsScreen` and related composables to use the new `SettingsUiState` and `SettingsUiEvent`. (`feature/settings/src/main/java/com/alxnophis/jetpack/settings/ui/composable/SettingsScreen.kt`) [[1]](diffhunk://#diff-a3cd3db4611e71b68195c02e2051b536909a7a94d53f5a0a4ae25e11b2c564e2L27-R44) [[2]](diffhunk://#diff-a3cd3db4611e71b68195c02e2051b536909a7a94d53f5a0a4ae25e11b2c564e2L62-R69) [[3]](diffhunk://#diff-a3cd3db4611e71b68195c02e2051b536909a7a94d53f5a0a4ae25e11b2c564e2L117-R117)

### Test Updates:
* Adjusted tests to use `SettingsUiState` instead of the deprecated `SettingsState`. (`feature/settings/src/androidTest/java/com/alxnophis/jetpack/settings/ui/composable/SettingsTest.kt`) [[1]](diffhunk://#diff-1ac01a3a1740f1a9ab4062c0bc0446e90cc1c427f3b7e75028848809a6e2a833L17-R17) [[2]](diffhunk://#diff-1ac01a3a1740f1a9ab4062c0bc0446e90cc1c427f3b7e75028848809a6e2a833L65-R66) [[3]](diffhunk://#diff-1ac01a3a1740f1a9ab4062c0bc0446e90cc1c427f3b7e75028848809a6e2a833L150-R150)

### Build Configuration:
* Added `APP_KEY_ALIAS` to debug and release configurations in the common Android Gradle file for better package identification. (`buildSystem/gradle/common-android-base.gradle`)

### ℹ️ Additional Info

* Add any additional useful context or info

### 🔗 Related Links

* Add helpful links for this pull request

### ✅ Checklist

- [x] Unit Tests
- [ ] Integration Tests
- [ ] Compose Tests
- [ ] Snapshot Tests
- [ ] Maestro Tests
- [ ] Updated string
- [x] Manually tested

### 📷 Screenshots
